### PR TITLE
Relax required fields for uploaded sample

### DIFF
--- a/src/main/java/validation/BusinessSampleUnit.java
+++ b/src/main/java/validation/BusinessSampleUnit.java
@@ -13,59 +13,46 @@ import javax.validation.constraints.Size;
 @Getter
 public class BusinessSampleUnit extends SampleUnitBase {
 
-  private static final String NON_BLANK_INTEGER_RE = "[+-]?[\\d]+";
+  private static final String NON_BLANK_INTEGER_RE = "[+-]?[\\d]+|^$";
   private static final String DATE_REGEX = "^\\s*$|^(0?[1-9]|[12][0-9]|3[01])/(0?[1-9]|1[012])/((19|20)\\d\\d)$";
 
-  @NotNull
-  @Size(min = 1, max = 1)
+  @Size(min = 0, max = 1)
   String checkletter;
 
-  @NotNull
-  @Size(min = 1, max = 5)
+  @Size(min = 0, max = 5)
   String frosic92;
 
-  @NotNull
-  @Size(min = 1, max = 5)
+  @Size(min = 0, max = 5)
   String rusic92;
 
-  @NotNull
-  @Size(min = 1, max = 5)
+  @Size(min = 0, max = 5)
   String frosic2007;
 
-  @NotNull
-  @Size(min = 1, max = 5)
+  @Size(min = 0, max = 5)
   String rusic2007;
 
-  @NotNull
   @Pattern(regexp = NON_BLANK_INTEGER_RE)
   String froempment;
 
-  @NotNull
   @Pattern(regexp = NON_BLANK_INTEGER_RE)
   String frotover;
 
-  @NotNull
-  @Size(min = 1, max = 10)
+  @Size(min = 0, max = 10)
   String entref;
 
-  @NotNull
-  @Size(min = 1, max = 1)
+  @Size(min = 0, max = 1)
   String legalstatus;
 
-  @NotNull
-  @Size(min = 1, max = 1)
+  @Size(min = 0, max = 1)
   String entrepmkr;
 
-  @NotNull
-  @Size(min = 1, max = 2)
+  @Size(min = 0, max = 2)
   String region;
 
-  @NotNull
   @Pattern(regexp = DATE_REGEX)
   String birthdate;
 
-  @NotNull
-  @Size(min = 1, max = 35)
+  @Size(min = 0, max = 35)
   String entname1;
 
   @Size(min = 0, max = 35)
@@ -75,7 +62,7 @@ public class BusinessSampleUnit extends SampleUnitBase {
   String entname3;
 
   @NotNull
-  @Size(min = 1, max = 35)
+  @Size(min = 0, max = 35)
   String runame1;
 
   @Size(min = 0, max = 35)
@@ -93,8 +80,7 @@ public class BusinessSampleUnit extends SampleUnitBase {
   @Size(min = 0, max = 35)
   String tradstyle3;
 
-  @NotNull
-  @Size(min = 1, max = 1)
+  @Size(min = 0, max = 1)
   String seltype;
 
   @Size(min = 0, max = 1)

--- a/src/main/java/validation/BusinessSampleUnit.java
+++ b/src/main/java/validation/BusinessSampleUnit.java
@@ -62,7 +62,7 @@ public class BusinessSampleUnit extends SampleUnitBase {
   String entname3;
 
   @NotNull
-  @Size(min = 0, max = 35)
+  @Size(min = 1, max = 35)
   String runame1;
 
   @Size(min = 0, max = 35)

--- a/src/main/java/validation/BusinessSampleUnit.java
+++ b/src/main/java/validation/BusinessSampleUnit.java
@@ -86,7 +86,6 @@ public class BusinessSampleUnit extends SampleUnitBase {
   @Size(min = 0, max = 1)
   String inclexcl;
 
-  @NotNull
   @Pattern(regexp = NON_BLANK_INTEGER_RE)
   String cell_no;
 


### PR DESCRIPTION
Remove NotNull requirement for all sample fields other than `runame1`

Works with
[rm-sample-service](https://github.com/ONSdigital/rm-sample-service/pull/24)
[rm-survey-service](https://github.com/ONSdigital/rm-survey-service/pull/28)

[Trello](https://trello.com/c/Fq5Xv2oW/155-us081-int-load-ashe-sample-for-r18-m)
[Confluence](https://digitaleq.atlassian.net/wiki/spaces/RASB/pages/259522840/US081+INT+-+Load+ASHE+Sample)