### PR TITLE
Add explicit sample unit validation

### DIFF
--- a/src/main/java/validation/SampleUnitBase.java
+++ b/src/main/java/validation/SampleUnitBase.java
@@ -5,9 +5,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import net.sourceforge.cobertura.CoverageIgnore;
-
-import javax.validation.constraints.NotNull;
+import net.sourceforge.cobertura.CoverageIgnore;  
 
 @CoverageIgnore
 @Data
@@ -17,12 +15,10 @@ import javax.validation.constraints.NotNull;
 @NoArgsConstructor
 public class SampleUnitBase {
 
-  @NotNull
   String sampleUnitRef;
 
   String sampleUnitType;
 
-  @NotNull
   String formType;
 
 }


### PR DESCRIPTION
In rm-samplesvc-api we have removed the javax validation for the sampleUnitRef and formType to allow social samples to be uploaded. We have explicitly added validation to ensure the sampleUnitRef or formType are not null or empty strings

Related changes in https://github.com/ONSdigital/rm-sample-service/pull/42