### PR TITLE
Allow formtype to be empty

### DIFF
--- a/src/main/resources/samplesvc/xsd/outbound/sample-unit.xsd
+++ b/src/main/resources/samplesvc/xsd/outbound/sample-unit.xsd
@@ -11,7 +11,7 @@
       <xsd:element name="id" type="xsd:string" minOccurs="0" maxOccurs="1"/>
       <xsd:element name="sampleUnitRef" type="xsd:string" minOccurs="1" maxOccurs="1"/>
       <xsd:element name="sampleUnitType" type="xsd:string" minOccurs="1" maxOccurs="1"/>
-      <xsd:element name="formType" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="formType" type="xsd:string" minOccurs="0" maxOccurs="1"/>
       <xsd:element name="collectionExerciseId" type="xsd:string" minOccurs="1" maxOccurs="1"/>
       <xsd:element name="sampleAttributes" minOccurs="0" maxOccurs="1">
         <xsd:complexType>


### PR DESCRIPTION
# Motivation and Context
Form types do not exist in social samples so we're making it optional in the message.

# What has changed
Made formtype nullable in *.xsd

# How to test?
Run all tests in samplesvc-api
