### PR TITLE
Change model

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/sample/representation/SampleUnitRequest.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/representation/SampleUnitRequest.java
@@ -1,7 +1,6 @@
 package uk.gov.ons.ctp.response.sample.representation;
 
 import io.swagger.annotations.ApiModelProperty;
-import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 import javax.validation.constraints.NotNull;
@@ -10,23 +9,14 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-/** Domain model object */
 @Data
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PUBLIC)
-public class CollectionExerciseJobCreationRequestDTO {
+public class SampleUnitRequest {
 
   @NotNull
   @ApiModelProperty(required = true)
   private UUID collectionExerciseId;
-
-  @NotNull
-  @ApiModelProperty(required = true)
-  private String surveyRef;
-
-  @NotNull
-  @ApiModelProperty(required = true)
-  private Date exerciseDateTime;
 
   @NotNull
   @ApiModelProperty(required = true)


### PR DESCRIPTION
# Motivation and Context
The API for getting sample units has changed significantly. It no longer
inserts something into the database which is later polled and actioned
on. The changes should be backwards compatible as the API should allow
fields that are not defined.

# What has changed
Changed CollectionExerciseJobCreationRequestDTO to SampleUnitRequest removing additional fields

# How to test?
1. Checkout https://github.com/ONSdigital/rm-sample-service/pull/62
2. Run integration tests

# Links
[PR](https://github.com/ONSdigital/rm-sample-service/pull/62)
[Trello](https://trello.com/c/45IDo0nJ/129-remove-polling-mechanism-from-sample-service)
