### PR TITLE
Add DTO to request size of sample unit

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/sample/representation/SampleUnitSizeRequestDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/representation/SampleUnitSizeRequestDTO.java
@@ -1,0 +1,21 @@
+package uk.gov.ons.ctp.response.sample.representation;
+
+import io.swagger.annotations.ApiModelProperty;
+import java.util.List;
+import java.util.UUID;
+import javax.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/** Domain model object */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PUBLIC)
+public class SampleUnitSizeRequestDTO {
+
+  @NotNull
+  @ApiModelProperty(required = true)
+  private List<UUID> sampleSummaryUUIDList;
+}


### PR DESCRIPTION
# Motivation and Context
Presently the Collection Exercise service doesn't know how many sample units it expects to be sent by the Sample service until it requests the sample units to be sent, which causes a race condition - if the sample units start arriving before Collex has managed to store the expected number to the database.

This was causing intermittent failures in the CI pipeline and in production, and a temporary fix was to ignore the count check if we didn't have an expected value, but this fix was less than ideal, because the race condition still potentially existed for very small sample sizes.

This fix is intended to close all the loopholes by asking for the number of expected sample units _before_ they start to be sent by the Sample service. This is **one of three** related PRs.

# What has changed
Added a new DTO API object so that Collex can make the request for the sample size to the Sample service.

# How to test?
Cannot be tested as this is just a new class to be used by other projects (i.e. Sample and Collex).

# Links
Trello: https://trello.com/c/DaKcP1zA/379-race-condition-fix-for-sample-collex-exchange-of-sample-data